### PR TITLE
feat: prefetch and reuse agent identity for password auth

### DIFF
--- a/sdk/auth/passwod.go
+++ b/sdk/auth/passwod.go
@@ -29,8 +29,10 @@ import (
 // It is used to authenticate with password.
 type PasswordAuth struct {
 	*BaseAuth
-	pwd      string
-	letftime time.Duration
+	pwd                string
+	letftime           time.Duration
+	prefetchedInfo     bool
+	prefetchedIdentity model.AgentIdentity
 }
 
 func NewPasswordAuth(pwd string) *PasswordAuth {
@@ -52,6 +54,11 @@ func (auth *PasswordAuth) GetLifetime() time.Duration {
 	return auth.letftime
 }
 
+func (auth *PasswordAuth) SetAgentIdentity(identity model.AgentIdentity) {
+	auth.prefetchedIdentity = identity
+	auth.prefetchedInfo = true
+}
+
 func (auth *PasswordAuth) Auth(request request.Request, context *request.Context) error {
 	method := auth.method
 	if method != nil {
@@ -60,9 +67,9 @@ func (auth *PasswordAuth) Auth(request request.Request, context *request.Context
 
 	switch auth.GetVersion() {
 	case AUTH_V1:
-		auth.method = newPasswordAuthV1(auth.pwd, auth.GetLifetime())
+		auth.method = newPasswordAuthV1(auth.pwd, auth.GetLifetime(), auth.prefetchedInfo, auth.prefetchedIdentity)
 	case AUTH_V2:
-		auth.method = newPasswordAuthV2(auth.pwd, auth.GetLifetime())
+		auth.method = newPasswordAuthV2(auth.pwd, auth.GetLifetime(), auth.prefetchedInfo, auth.prefetchedIdentity)
 	default:
 		return ErrNotSupportedAuthVersion
 	}
@@ -71,34 +78,46 @@ func (auth *PasswordAuth) Auth(request request.Request, context *request.Context
 }
 
 type PasswordAuthMethod struct {
-	pwd           string
-	pk            string
-	identityCheck bool
-	letftime      time.Duration
+	pwd                string
+	pk                 string
+	identityCheck      bool
+	letftime           time.Duration
+	prefetchedIdentity model.AgentIdentity
 }
 
 func (auth *PasswordAuthMethod) Reset() {
 	auth.pk = ""
 	auth.identityCheck = false
+	auth.prefetchedIdentity = model.UNIDENTIFIED
 }
 
 func (auth *PasswordAuthMethod) checkIdentity(req request.Request) error {
 	if !auth.identityCheck {
-		identity, err := util.GetIdentityWithOptions(req.GetServer(), req.GetProtocol(), req.GetTLSConfig())
-		if err != nil {
-			return err
+		identity := auth.prefetchedIdentity
+		if identity == model.UNIDENTIFIED {
+			var err error
+			identity, err = util.GetIdentityWithOptions(req.GetServer(), req.GetProtocol(), req.GetTLSConfig())
+			if err != nil {
+				return err
+			}
 		}
 		if identity == model.SINGLE {
 			auth.pwd = ""
 			log.Warn("Identity is single, password is not needed.")
 		}
 		auth.identityCheck = true
+		auth.prefetchedIdentity = model.UNIDENTIFIED
 	}
 	return nil
 }
-func newPasswordAuthMethod(pwd string, letftime time.Duration) *PasswordAuthMethod {
+
+func newPasswordAuthMethod(pwd string, letftime time.Duration, prefetched bool, identity model.AgentIdentity) *PasswordAuthMethod {
+	if !prefetched {
+		identity = model.UNIDENTIFIED
+	}
 	return &PasswordAuthMethod{
-		pwd:      pwd,
-		letftime: letftime,
+		pwd:                pwd,
+		letftime:           letftime,
+		prefetchedIdentity: identity,
 	}
 }

--- a/sdk/auth/passwod_v1.go
+++ b/sdk/auth/passwod_v1.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/oceanbase/obshell-sdk-go/internal/util"
+	"github.com/oceanbase/obshell-sdk-go/model"
 	"github.com/oceanbase/obshell-sdk-go/sdk/request"
 )
 
@@ -28,9 +29,9 @@ type PasswordAuthV1 struct {
 	*PasswordAuthMethod
 }
 
-func newPasswordAuthV1(pwd string, letftime time.Duration) *PasswordAuthV1 {
+func newPasswordAuthV1(pwd string, letftime time.Duration, prefetched bool, identity model.AgentIdentity) *PasswordAuthV1 {
 	return &PasswordAuthV1{
-		PasswordAuthMethod: newPasswordAuthMethod(pwd, letftime),
+		PasswordAuthMethod: newPasswordAuthMethod(pwd, letftime, prefetched, identity),
 	}
 }
 

--- a/sdk/auth/passwod_v2.go
+++ b/sdk/auth/passwod_v2.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/oceanbase/obshell-sdk-go/internal/util"
+	"github.com/oceanbase/obshell-sdk-go/model"
 	"github.com/oceanbase/obshell-sdk-go/sdk/request"
 )
 
@@ -38,9 +39,9 @@ type PasswordAuthV2 struct {
 	*PasswordAuthMethod
 }
 
-func newPasswordAuthV2(pwd string, letftime time.Duration) *PasswordAuthV2 {
+func newPasswordAuthV2(pwd string, letftime time.Duration, prefetched bool, identity model.AgentIdentity) *PasswordAuthV2 {
 	return &PasswordAuthV2{
-		PasswordAuthMethod: newPasswordAuthMethod(pwd, letftime),
+		PasswordAuthMethod: newPasswordAuthMethod(pwd, letftime, prefetched, identity),
 	}
 }
 

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/oceanbase/obshell-sdk-go/internal/util"
+	"github.com/oceanbase/obshell-sdk-go/model"
 	"github.com/oceanbase/obshell-sdk-go/sdk/auth"
 	"github.com/oceanbase/obshell-sdk-go/sdk/option"
 	"github.com/oceanbase/obshell-sdk-go/sdk/request"
@@ -139,11 +140,21 @@ func (c *Client) GetProtocol() string {
 	return c.protocol
 }
 
+func (c *Client) applyAgentInfo(auther auth.Auther, agentInfo *model.AgentRunStatus) {
+	if auther == nil || agentInfo == nil {
+		return
+	}
+	if passwordAuth, ok := auther.(*auth.PasswordAuth); ok {
+		passwordAuth.SetAgentIdentity(agentInfo.Identity)
+	}
+}
+
 func (c *Client) confirmAuthVersion() error {
 	agentInfo, err := util.GetInfoWithOptions(c.GetServer(), c.protocol, c.tlsConfig)
 	if err != nil {
 		return errors.Wrap(err, "get version failed")
 	}
+	c.applyAgentInfo(c.auth, agentInfo)
 
 	if !c.auth.IsAutoSelectVersion() {
 		if !c.auth.IsSupported(c.auth.GetVersion()) {
@@ -198,6 +209,8 @@ func (c *Client) tryCandidateAuth(request request.Request, response responselib.
 	if err != nil {
 		return false
 	}
+	c.applyAgentInfo(c.auth, agentInfo)
+	c.applyAgentInfo(c.candidateAuth, agentInfo)
 
 	// Check if the agent version is less than or equal to 4.2.4.
 	if auth.VERSION_4_2_4.BeforeOrEquals(agentInfo.Version) {


### PR DESCRIPTION
## Summary
  优化 SDK 认证流程，减少一次重复的 `/api/v1/info` 请求。

  ## Solution Description
  第一次 `/api/v1/info` 返回中已经包含 identity 信息，因此在认证流程中复用该结果，避免在 `checkIdentity()` 中再次请求 `/api/v1/info`。